### PR TITLE
Feat welcome screen

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,4 +1,4 @@
 org.gradle.jvmargs=-Xmx4G -XX:MaxMetaspaceSize=2G -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
 android.enableJetifier=true
-org.gradle.java.home=C:\\Program Files\\Java\\jdk-17
+#org.gradle.java.home=C:\\Program Files\\Java\\jdk-17

--- a/lib/Screens/intro_screen.dart
+++ b/lib/Screens/intro_screen.dart
@@ -131,18 +131,21 @@ class _IntroScreenState extends State<IntroScreen>
     );
   }
 
-  /// Exits the application.
   void _exitGame() {
     SystemNavigator.pop();
   }
 
   @override
   Widget build(BuildContext context) {
+    final screenSize = MediaQuery.of(context).size;
+    final screenHeight = screenSize.height;
+    final screenWidth = screenSize.width;
+
     return Scaffold(
       body: Stack(
         fit: StackFit.expand,
         children: [
-          // 1. Background Image
+          // 1. Background Image (no change)
           Image.asset(
             'assets/Theme/a.png',
             fit: BoxFit.cover,
@@ -150,74 +153,113 @@ class _IntroScreenState extends State<IntroScreen>
             colorBlendMode: BlendMode.darken,
           ),
 
-          // 2. UI Elements in the foreground
-          Column(
-            mainAxisAlignment: MainAxisAlignment.start,
-            children: [
-              // --- 11. Animate the Logo ---
-              AnimatedBuilder(
-                // Listen to BOTH controllers
-                animation: Listenable.merge([_entryController, _bobbingController]),
-                builder: (BuildContext context, Widget? child) {
-                  return Transform.translate(
-                    // ADD the slide value and the bob value together
-                    offset: Offset(0, _logoSlideAnimation.value + _logoBobAnimation.value),
-                    child: child,
-                  );
-                },
-                child: SizedBox(
-                  width: 600,
-                  height: 400,
-                  child: Image.asset(
-                    "assets/Theme/NM.png",
+          // --- 2. Wrap UI in SafeArea and SingleChildScrollView ---
+          // SafeArea avoids notches/system bars
+          // SingleChildScrollView fixes vertical overflow by allowing scrolling
+          SafeArea(
+            child: SingleChildScrollView(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.start,
+                children: [
+                  // --- 3. Animate the Logo (with responsive size) ---
+                  AnimatedBuilder(
+                    animation: Listenable.merge(
+                        [_entryController, _bobbingController]),
+                    builder: (BuildContext context, Widget? child) {
+                      return Transform.translate(
+                        offset: Offset(
+                            0,
+                            _logoSlideAnimation.value +
+                                _logoBobAnimation.value),
+                        child: child,
+                      );
+                    },
+                    child: SizedBox(
+                      // --- Use relative sizes instead of 600x400 ---
+                      width: screenWidth * 0.9, // 90% of screen width
+                      height: screenHeight * 0.4, // 40% of screen height
+                      child: Image.asset(
+                        "assets/Theme/NM.png",
+                        // --- Add .contain to prevent image distortion ---
+                        fit: BoxFit.contain,
+                      ),
+                    ),
                   ),
-                ),
-              ),
 
-              const SizedBox(height: 4.0), // Spacer
+                  const SizedBox(height: 4.0), // Spacer
 
-              // --- 12. Animate the Start Button ---
-              AnimatedBuilder(
-                animation: Listenable.merge([_entryController, _bobbingController]),
-                builder: (context, child) {
-                  return Transform.translate(
-                    offset: Offset(0, _buttonSlideAnimation.value + _buttonBobAnimation.value),
-                    child: child,
-                  );
-                },
-                child: _buildImageButton(
-                    imagePath: 'assets/Theme/StartBtn.png', onTap: _startGame),
-              ),
-              const SizedBox(height: 20.0),
+                  // --- 4. Animate the Start Button (with responsive size) ---
+                  AnimatedBuilder(
+                    animation: Listenable.merge(
+                        [_entryController, _bobbingController]),
+                    builder: (context, child) {
+                      return Transform.translate(
+                        offset: Offset(
+                            0,
+                            _buttonSlideAnimation.value +
+                                _buttonBobAnimation.value),
+                        child: child,
+                      );
+                    },
+                    child: _buildImageButton(
+                      imagePath: 'assets/Theme/StartBtn.png',
+                      onTap: _startGame,
+                      // --- Pass in relative sizes ---
+                      width: screenWidth * 0.7, // 70% of screen width
+                      height: screenHeight * 0.12, // 12% of screen height
+                    ),
+                  ),
+                  const SizedBox(height: 20.0),
 
-              // --- 13. Animate the Rules Button ---
-              AnimatedBuilder(
-                animation: Listenable.merge([_entryController, _bobbingController]),
-                builder: (context, child) {
-                  return Transform.translate(
-                    offset: Offset(0, _buttonSlideAnimation.value + _buttonBobAnimation.value),
-                    child: child,
-                  );
-                },
-                child: _buildImageButton(
-                    imagePath: 'assets/Theme/rules.png',
-                    onTap: _showRulesDialog),
-              ),
-              const SizedBox(height: 20.0),
+                  // --- 5. Animate the Rules Button (with responsive size) ---
+                  AnimatedBuilder(
+                    animation: Listenable.merge(
+                        [_entryController, _bobbingController]),
+                    builder: (context, child) {
+                      return Transform.translate(
+                        offset: Offset(
+                            0,
+                            _buttonSlideAnimation.value +
+                                _buttonBobAnimation.value),
+                        child: child,
+                      );
+                    },
+                    child: _buildImageButton(
+                      imagePath: 'assets/Theme/rules.png',
+                      onTap: _showRulesDialog,
+                      // --- Pass in relative sizes ---
+                      width: screenWidth * 0.7,
+                      height: screenHeight * 0.12,
+                    ),
+                  ),
+                  const SizedBox(height: 20.0),
 
-              // --- 14. Animate the Exit Button ---
-              AnimatedBuilder(
-                animation: Listenable.merge([_entryController, _bobbingController]),
-                builder: (context, child) {
-                  return Transform.translate(
-                    offset: Offset(0, _buttonSlideAnimation.value + _buttonBobAnimation.value),
-                    child: child,
-                  );
-                },
-                child: _buildImageButton(
-                    imagePath: 'assets/Theme/exit.png', onTap: _exitGame),
+                  // --- 6. Animate the Exit Button (with responsive size) ---
+                  AnimatedBuilder(
+                    animation: Listenable.merge(
+                        [_entryController, _bobbingController]),
+                    builder: (context, child) {
+                      return Transform.translate(
+                        offset: Offset(
+                            0,
+                            _buttonSlideAnimation.value +
+                                _buttonBobAnimation.value),
+                        child: child,
+                      );
+                    },
+                    child: _buildImageButton(
+                      imagePath: 'assets/Theme/exit.png',
+                      onTap: _exitGame,
+                      // --- Pass in relative sizes ---
+                      width: screenWidth * 0.7,
+                      height: screenHeight * 0.12,
+                    ),
+                  ),
+                  // --- Add final padding so the last button doesn't hug the bottom ---
+                  const SizedBox(height: 30.0),
+                ],
               ),
-            ],
+            ),
           ),
         ],
       ),

--- a/lib/Screens/welcome_screen.dart
+++ b/lib/Screens/welcome_screen.dart
@@ -1,0 +1,229 @@
+import 'package:flutter/material.dart';
+import 'package:number_master/Screens/intro_screen.dart';
+import 'package:number_master/Transitions/pageRoute.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'dart:async';
+
+class WelcomeScreen extends StatefulWidget {
+  const WelcomeScreen({super.key});
+
+  @override
+  State<WelcomeScreen> createState() => _WelcomeScreenState();
+}
+
+class _WelcomeScreenState extends State<WelcomeScreen> {
+  final PageController _pageController = PageController();
+  int _currentPage = 0;
+
+  // --- 1. Define the content for our pages with THEMED colors ---
+  final List<Map<String, dynamic>> _pageData = [
+    {
+      "icon": Icons.numbers_rounded,
+      "title": "Welcome to Number Master!",
+      "description":
+          "Get ready to challenge your mind and find the matching numbers.",
+      "color": Colors.white,
+    },
+    {
+      "icon": Icons.touch_app_rounded,
+      "title": "How to Play",
+      "description":
+          "Tap on any two numbers to see if they match. Find all the pairs to win the level.",
+      "color": Colors.white
+    },
+    {
+      "icon": Icons.celebration_rounded,
+      "title": "Ready to Start?",
+      "description":
+          "Complete all the levels and become the ultimate Number Master!",
+      "color": Colors.white
+    }
+  ];
+
+  @override
+  void dispose() {
+    _pageController.dispose();
+    super.dispose();
+  }
+
+  /// Sets the flag in SharedPreferences and navigates to the IntroScreen.
+  Future<void> _getStarted() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool('hasSeenWelcome', true);
+
+    if (mounted) {
+      Navigator.of(context).pushReplacement(
+        ScreenTransition.createRoute(const IntroScreen()),
+      );
+    }
+  }
+
+  /// Handles button press
+  void _onButtonPressed() {
+    if (_currentPage == _pageData.length - 1) {
+      // Last page: Get Started
+      _getStarted();
+    } else {
+      // Not last page: Go to next page
+      _pageController.nextPage(
+        duration: const Duration(milliseconds: 400),
+        curve: Curves.easeInOut,
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // --- 2. Use a Stack to layer background and content ---
+    return Scaffold(
+      backgroundColor: Colors.transparent, // Make scaffold transparent
+      body: Stack(
+        fit: StackFit.expand,
+        children: [
+          // --- 3. Add the same background image as other screens ---
+          Image.asset(
+            'assets/Theme/a.png',
+            fit: BoxFit.cover,
+            color: Colors.black.withOpacity(0.5),
+            colorBlendMode: BlendMode.darken,
+          ),
+
+          // --- 4. Content layer ---
+          SafeArea(
+            child: Column(
+              children: [
+                // 1. PageView for swipeable content
+                Expanded(
+                  child: PageView.builder(
+                    controller: _pageController,
+                    itemCount: _pageData.length,
+                    onPageChanged: (int page) {
+                      setState(() {
+                        _currentPage = page;
+                      });
+                    },
+                    itemBuilder: (context, index) {
+                      return _buildPageContent(
+                        icon: _pageData[index]['icon'],
+                        title: _pageData[index]['title'],
+                        description: _pageData[index]['description'],
+                        color: _pageData[index]['color'],
+                      );
+                    },
+                  ),
+                ),
+
+                // 2. Page Indicator
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: _buildPageIndicator(),
+                ),
+                const SizedBox(height: 30),
+
+                // 3. Dynamic "Next" / "Get Started" Button
+                Padding(
+                  padding: const EdgeInsets.symmetric(
+                      horizontal: 24.0, vertical: 20.0),
+                  child: ElevatedButton(
+                    onPressed: _onButtonPressed,
+
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: Colors.amber,
+                      foregroundColor: Colors.white, // Use white text
+                      minimumSize:
+                          const Size(double.infinity, 60), // Full width
+                      padding: const EdgeInsets.symmetric(vertical: 16),
+                      textStyle: const TextStyle(
+                        fontSize: 20,
+                        fontWeight: FontWeight.bold,
+                      ),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(12),
+                        // side: BorderSide(
+                        //   color:
+                        //       _pageData[_currentPage]['color'] == Colors.amber
+                        //           ? Colors.yellowAccent
+                        //           : Colors.orange,
+                        //   width: 2,
+                        // ),
+                      ),
+                      elevation: 8,
+                    ),
+                    // Change text based on the current page
+                    child: Text(
+                      _currentPage == _pageData.length - 1
+                          ? 'Get Started'
+                          : 'Next',
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// Helper widget to build the content for each page
+  Widget _buildPageContent({
+    required IconData icon,
+    required String title,
+    required String description,
+    required Color color,
+  }) {
+    return Padding(
+      padding: const EdgeInsets.all(32.0),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          Icon(icon, size: 140, color: color),
+          const SizedBox(height: 40),
+          Text(
+            title,
+            textAlign: TextAlign.center,
+            style: TextStyle(
+              color: color,
+              fontSize: 32,
+              fontWeight: FontWeight.bold,
+              letterSpacing: 1.1,
+            ),
+          ),
+          const SizedBox(height: 24),
+          Text(
+            description,
+            textAlign: TextAlign.center,
+            style: const TextStyle(
+              color: Colors.white70,
+              fontSize: 18,
+              height: 1.5,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  List<Widget> _buildPageIndicator() {
+    List<Widget> list = [];
+    for (int i = 0; i < _pageData.length; i++) {
+      list.add(i == _currentPage ? _indicator(true) : _indicator(false));
+    }
+    return list;
+  }
+
+  /// Helper widget for a single indicator dot
+  Widget _indicator(bool isActive) {
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 150),
+      margin: const EdgeInsets.symmetric(horizontal: 8.0),
+      height: 10.0,
+      width: isActive ? 24.0 : 10.0,
+      decoration: BoxDecoration(
+        color: isActive ? _pageData[_currentPage]['color'] : Colors.white30,
+        borderRadius: const BorderRadius.all(Radius.circular(12)),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,20 +1,28 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:number_master/Bloc/game_bloc.dart';
-
 import 'package:number_master/Screens/intro_screen.dart';
+import 'package:number_master/Screens/welcome_screen.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
-void main() {
-  runApp(const MyApp());
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+
+  final prefs = await SharedPreferences.getInstance();
+
+  final bool hasSeenWelcome = prefs.getBool('hasSeenWelcome') ?? false;
+
+  runApp(MyApp(hasSeenWelcome: hasSeenWelcome));
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({super.key});
+  final bool hasSeenWelcome;
+
+  const MyApp({super.key, required this.hasSeenWelcome});
 
   @override
   Widget build(BuildContext context) {
     return BlocProvider(
-      // The GameBloc manages all the game state and logic.
       create: (context) => GameBloc(),
       child: MaterialApp(
         title: 'Number Master',
@@ -44,7 +52,7 @@ class MyApp extends StatelessWidget {
             ),
           ),
         ),
-        home: const IntroScreen(),
+        home: hasSeenWelcome ? const IntroScreen() : const WelcomeScreen(),
         debugShowCheckedModeBanner: false,
       ),
     );

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,7 +6,9 @@ import FlutterMacOS
 import Foundation
 
 import path_provider_foundation
+import shared_preferences_foundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
+  SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -89,6 +89,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  file:
+    dependency: transitive
+    description:
+      name: file
+      sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -112,6 +120,11 @@ packages:
     version: "4.0.0"
   flutter_test:
     dependency: "direct dev"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
     description: flutter
     source: sdk
     version: "0.0.0"
@@ -283,6 +296,62 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.1.5+1"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      sha256: "6e8bf70b7fef813df4e9a36f658ac46d107db4b4cfe1048b477d4e453a8159f5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.3"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      sha256: "34266009473bf71d748912da4bf62d439185226c03e01e2d9687bc65bbfcb713"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.15"
+  shared_preferences_foundation:
+    dependency: transitive
+    description:
+      name: shared_preferences_foundation
+      sha256: "1c33a907142607c40a7542768ec9badfd16293bac51da3a4482623d15845f88b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.5"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      sha256: "580abfd40f415611503cae30adf626e6656dfb2f0cee8f465ece7b6defb40f2f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      sha256: "57cbf196c486bc2cf1f02b85784932c6094376284b3ad5779d1b1c6c6a816b80"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      sha256: c49bd060261c9a3f0ff445892695d6212ff603ef3115edbb448509d407600019
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.3"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      sha256: "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,6 +39,7 @@ dependencies:
   equatable:
   bloc: ^9.1.0
   google_fonts: ^6.3.2
+  shared_preferences: ^2.2.3
 
 dev_dependencies:
   flutter_test:

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -13,7 +13,7 @@ import 'package:number_master/main.dart';
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+    await tester.pumpWidget(const MyApp(hasSeenWelcome: true));
 
     // Verify that our counter starts at 0.
     expect(find.text('0'), findsOneWidget);


### PR DESCRIPTION
Implements a new carousel-style welcome screen (onboarding flow) that appears only on the user's first app launch.

- Uses PageView.builder to create a 3-page swipeable intro.
- Integrates `shared_preferences` to set and check a 'hasSeenWelcome' flag, ensuring the screen is only shown once.
- Styles the screen to match the existing app theme, reusing the `a.png` background, themed colors and button styles from the game and intro screens for a consistent UI.
- The button dynamically changes from "Next" to "Get Started" on the final page.

https://github.com/user-attachments/assets/3996766d-dc8f-490b-a0f3-d169c857086d

